### PR TITLE
Update esprima-fb

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Miller Medeiros <http://blog.millermedeiros.com>",
   "license": "MIT",
   "dependencies": {
-    "esprima-fb": "^4001.3001.0-dev-harmony-fb"
+    "esprima-fb": "^7001.1.0-dev-harmony-fb"
   },
   "devDependencies": {
     "mocha": "~1.7",


### PR DESCRIPTION
The latest versions of esprima-fb fix a large swath of issues and also align with the final ES6 modules spec. ES6 Module Transpiler, recast, ast-types etc have all made the move and while I see an interest in this project to move to acorn I think in the short term this upgrade would be very nice.

I am sure tests are broken, just opening this PR now in case there are objections in principal.