### PR TITLE
Ignore TryStatement's "handlers" property in favor of "handler"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Miller Medeiros <http://blog.millermedeiros.com>",
   "license": "MIT",
   "dependencies": {
-    "esprima": "^2.0"
+    "esprima": "^2.1"
   },
   "devDependencies": {
     "mocha": "~1.7",

--- a/rocambole.js
+++ b/rocambole.js
@@ -21,9 +21,13 @@ exports.BYPASS_RECURSION = {
     next : true,
     prev : true,
 
-    // esprima@2.1 introduces a "handler" property on TryStatement, so we would
+    // esprima@2.1 introduces a "handler" property on TryStatement in addition to
+    // "handlers", which contains the same node, so we would
     // loop the same node twice (see jquery/esprima/issues/1031 and #264)`
-    handler : true,
+    //
+    // Instead, ignore the handlers list in favor of the standardized "handler"
+    // property: https://github.com/eslint/eslint/issues/1930
+    handlers : true,
 
     // IMPORTANT! "value" can't be bypassed since it is used by object
     // expression


### PR DESCRIPTION
I'm making this change because espree@2.x removes `handlers` entirely, so `CatchClause`s wouldn't be processed. Also, [estree has adopted `handler` in favor of `handlers`] https://github.com/eslint/eslint/issues/1930).

Esprima 2.1 and above  (and pre-2.x espree) introduce `handler` while maintaining the old `handlers` array, so we can use it there too but must ignore `handlers`. 

Flipping the ignore to the list, which [would only have the one handler anyway](https://github.com/jquery/esprima/blob/master/esprima.js#L2245), makes this all possible.