### PR TITLE
Test adjustment: add `sourceType` to the augmented AST for an empty program

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Miller Medeiros <http://blog.millermedeiros.com>",
   "license": "MIT",
   "dependencies": {
-    "esprima": "^2.1"
+    "esprima": "~2.7.1"
   },
   "devDependencies": {
     "mocha": "~1.7",

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -324,6 +324,7 @@ describe('parse', function () {
             var ast = rocambole.parse('');
             expect(ast).to.eql({
                 type: 'Program',
+                sourceType: 'script',
                 body: [],
                 range: [0,0],
                 comments: [],


### PR DESCRIPTION
`sourceType` was introduced in Esprima 2.6, to distinguish between parsing a module vs a script.